### PR TITLE
Add PUT method to the server specifications

### DIFF
--- a/specifications/server.md
+++ b/specifications/server.md
@@ -1,6 +1,6 @@
 # UnifiedPush Server Interface
 
-UnifiedPush Spec: SERV_1.2.0
+UnifiedPush Spec: SERV_1.3.0
 
 ## Endpoint
 
@@ -21,7 +21,7 @@ Application servers or gateways SHOULD check this when registering push to avoid
 
 ### Request
 
-The pusher sends an HTTP request to the endpoint using the POST method. The contents of the POST body will be the message received by the connector library. The length of the message MUST be between 1 byte and 4096 bytes (inclusive).
+The pusher sends an HTTP request to the endpoint using the POST or the PUT method. The message body of the POST or PUT request will be the message received by the connector library. The length of the message MUST be between 1 byte and 4096 bytes (inclusive).
 
 
 ### Responses
@@ -34,7 +34,7 @@ The push server MUST return a status code 201 if it successfully accepts the pus
 
 The push server MUST add the header `TTL: 0` to its response. The application server MAY ignore it.
 
-In this case, the distributor MUST send EXACTLY the contents of the HTTP POST request to the connector library.
+In this case, the distributor MUST send EXACTLY the message body of the HTTP POST or PUT request to the connector library.
 
 ### 3xx
 


### PR DESCRIPTION
Adding support for the PUT method will make UnifiedPush compatible with the legacy *simple push* protocol (from firefox os). The most known project supporting it is Telegram: https://core.telegram.org/api/push-updates (it has been tagged as UP compatible by mistake ATM).

**WebPush (rfc8030) doesn't specify any PUT method, so this doesn't conflict with its support.**

This is a backward compatible change.

Example of issues where users talked about it:
- https://codeberg.org/NextPush/uppush/issues/5#issuecomment-1559568
- https://github.com/UnifiedPush/wishlist/issues/18

@drizzt has done a PUT to POST gateway for Mercurygram for this:
- https://github.com/drizzt/Mercurygram/tree/Mercurygram?tab=readme-ov-file#unifiedpush-put-to-post-gateway

Ping for the owners of a distributor project:
@binwiederhier (you won't have to do anything, ntfy supports PUT for UnifiedPush endpoints already :) ) @inputmice